### PR TITLE
sorting dictionary before hashing data

### DIFF
--- a/SciXPipelineUtils/scix_id.py
+++ b/SciXPipelineUtils/scix_id.py
@@ -243,10 +243,13 @@ def generate_scix_id(
     if hash_data_type == "bib_data":
         if type(hash_data) != dict:
             try:
-                hash_data_raw = json.loads(hash_data)
-                hash_data = json.dumps(hash_data_raw, sort_keys=True)
+                hash_data = json.loads(hash_data)
+
             except ValueError as e:
                 raise e
+
+        # Use json.dumps with sort_keys=True to sort all nested dictionary keys
+        hash_data = json.loads(json.dumps(hash_data, sort_keys=True))
         hashed_data = generate_bib_data_hash(
             hash_data, strip_characters=strip_characters, user_fields=user_fields
         )

--- a/SciXPipelineUtils/scix_id.py
+++ b/SciXPipelineUtils/scix_id.py
@@ -243,7 +243,8 @@ def generate_scix_id(
     if hash_data_type == "bib_data":
         if type(hash_data) != dict:
             try:
-                hash_data = json.loads(hash_data)
+                hash_data_raw = json.loads(hash_data)
+                hash_data = json.dumps(hash_data_raw, sort_keys=True)
             except ValueError as e:
                 raise e
         hashed_data = generate_bib_data_hash(

--- a/tests/test_scix_id.py
+++ b/tests/test_scix_id.py
@@ -68,7 +68,7 @@ class TestSciXIDImplementation(TestCase):
         }
         scix_id = scixid.generate_scix_id(test_bib_data)
         scix_id_2 = scixid.generate_scix_id(json.dumps(test_bib_data))
-        self.assertEqual(scix_id, "7SNR-3N03-VSD6")
+        self.assertEqual(scix_id, "9153-JA78-G9SG")
         self.assertEqual(scix_id, scix_id_2)
 
     def test_generate_scix_id_user_fields(self):
@@ -81,7 +81,7 @@ class TestSciXIDImplementation(TestCase):
         user_fields = ["id"]
         scix_id = scixid.generate_scix_id(test_bib_data, user_fields=user_fields)
         scix_id_2 = scixid.generate_scix_id(test_bib_data)
-        self.assertEqual(scix_id, "1NMC-KCFG-RVH8")
+        self.assertEqual(scix_id, "3YG1-418S-68AF")
         self.assertNotEqual(scix_id, scix_id_2)
 
     def test_generate_scix_id_special_characters_true(self):
@@ -93,7 +93,7 @@ class TestSciXIDImplementation(TestCase):
         }
         scix_id = scixid.generate_scix_id(test_bib_data)
         scix_id_2 = scixid.generate_scix_id(json.dumps(test_bib_data))
-        self.assertEqual(scix_id, "7SNR-3N03-VSD6")
+        self.assertEqual(scix_id, "9153-JA78-G9SG")
         self.assertEqual(scix_id, scix_id_2)
 
     def test_generate_scix_id_special_characters_true_comparison(self):
@@ -113,7 +113,7 @@ class TestSciXIDImplementation(TestCase):
 
         scix_id = scixid.generate_scix_id(test_bib_data)
         scix_id_2 = scixid.generate_scix_id(test_bib_data_2)
-        self.assertEqual(scix_id, "7SNR-3N03-VSD6")
+        self.assertEqual(scix_id, "9153-JA78-G9SG")
         self.assertEqual(scix_id, scix_id_2)
 
     def test_generate_scix_id_special_characters_false(self):
@@ -125,7 +125,7 @@ class TestSciXIDImplementation(TestCase):
         }
         scix_id = scixid.generate_scix_id(test_bib_data, strip_characters=False)
         scix_id_2 = scixid.generate_scix_id(test_bib_data)
-        self.assertEqual(scix_id, "APGB-1BCS-SAG1")
+        self.assertEqual(scix_id, "8Z91-4S23-1KJX")
         self.assertNotEqual(scix_id, scix_id_2)
 
     def test_generate_scix_id_other(self):
@@ -136,5 +136,5 @@ class TestSciXIDImplementation(TestCase):
             "abs": ["words"],
         }
         scix_id = scixid.generate_scix_id(json.dumps(test_bib_data), hash_data_type="other")
-        self.assertNotEqual(scix_id, "7SNR-3N03-VSD6")
+        self.assertNotEqual(scix_id, "9153-JA78-G9SG")
         self.assertEqual(scix_id, "6N22-EN04-7GHF")


### PR DESCRIPTION
Ensures that bib_data dictionary is in the same order between dev and prod by sorting the dict keys. 